### PR TITLE
IOS-1444 and IOS-1099: Fix Video Player control state issues.

### DIFF
--- a/VideoRig/VideoRig/ENHAVPlayer/ENHAVPlayerViewController.m
+++ b/VideoRig/VideoRig/ENHAVPlayer/ENHAVPlayerViewController.m
@@ -871,11 +871,7 @@ static const NSTimeInterval kENHInteractionTimeoutInterval = 3.0;
 -(void)playerRateDidChange:(NSDictionary *)change
 {
   [self syncPlayPauseButtons];
-  if ([self.player rate] == 0.0)
-  {
-    [self showPlayerControlsView];
-  }
-  else
+  if ([self.player rate] > 0.0)
   {
     [self deferredHidePlayerControlsView];
   }
@@ -996,6 +992,7 @@ static const NSTimeInterval kENHInteractionTimeoutInterval = 3.0;
     if (playerItem == [player.items lastObject])
     {
       [player pause];
+      [self showPlayerControlsView];
     }
     else
     {
@@ -1005,6 +1002,7 @@ static const NSTimeInterval kENHInteractionTimeoutInterval = 3.0;
   else
   {
     [self.player pause];
+    [self showPlayerControlsView];
   }
 }
 


### PR DESCRIPTION
IOS-1444 and IOS-1099: Fix Video Player control state issues.

RFC: Do not show player controls if the currentTime and currentItem.duration information is not available to show.  Also do not show the video player controls prematurely while auto-playing the video resource.  Show controls when the video player currentItem completes playing the video.