### PR TITLE
IOS-1447: Fix Full Screen Button regression bug.

### DIFF
--- a/VideoRig/VideoRig/ENHAVPlayer/ENHAVPlayerViewController.h
+++ b/VideoRig/VideoRig/ENHAVPlayer/ENHAVPlayerViewController.h
@@ -37,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 -(void)showFullscreenView:(BOOL)goFullScreen
              withDuration:(NSTimeInterval)duration
-                  options:(UIViewAnimationOptions)options;
+                  options:(UIViewAnimationOptions)options
+                   sender:(id)sender;
 
 @property (nonatomic, copy, nullable) void (^playerItemStatusHandler)(AVPlayerItemStatus status);
 


### PR DESCRIPTION
RFC: Previous bug help listen to the Orientation change notifications changes carefull however since these notification states fire off at random times it can throw of the UIView state when showFullscreenView() method is called.  The method is very condense to I had to isolate specific UIView operations using a flag that is tied directly to a the type of object that is initiating the orientation + fullview operations.  In order to isolate these operations I had to determine if the ‘Full Screen Button’ is pressed or if the orientation notification is consumed.  Each origin type has a different set of operations and process the view in a particular manner.